### PR TITLE
[fix]: file extension "tanis" to "tanis.md"

### DIFF
--- a/builder_follow_builder.md
+++ b/builder_follow_builder.md
@@ -75,4 +75,4 @@ Here is a markdown table with Farcaster handles for the Starknet Builders:
 | Glihm          | [@glihm](https://warpcast.com/glihm)                       |
 | Oak            | [@droak](https://warpcast.com/droak)                       |
 | Robert         | [@robertkp](https://warpcast.com/robertkp)                 |
-| emin.pdf       | [@0xemin](https://warpcast.com/0xemin)
+| emin.pdf       | [@0xemin](https://warpcast.com/0xemin)                     |

--- a/builder_follow_builder.md
+++ b/builder_follow_builder.md
@@ -75,3 +75,4 @@ Here is a markdown table with Farcaster handles for the Starknet Builders:
 | Glihm          | [@glihm](https://warpcast.com/glihm)                       |
 | Oak            | [@droak](https://warpcast.com/droak)                       |
 | Robert         | [@robertkp](https://warpcast.com/robertkp)                 |
+| emin.pdf       | [@0xemin](https://warpcast.com/0xemin)

--- a/frames/find-starknet-frens/tanis.md
+++ b/frames/find-starknet-frens/tanis.md
@@ -1,0 +1,10 @@
+# Find you starket friends on Farcaster!
+
+The project implements a farcaster frame, which allows you to find starknet builders on warpcast!
+
+![Alt text](image.png)
+
+## How does it work?
+- It parses the list from [here](https://github.com/keep-starknet-strange/starknet-warpcast/blob/main/builder_follow_builder.md).
+- Then uses [puppeteer](https://pptr.dev/) to screenshot all profiles, by running a headless chrome in the background!
+- Then randomly suggests starknet profiles!


### PR DESCRIPTION
The file extension of the `tanis` (`frames/find-starknet-frens/tanis`) was not specified. Therefore, I changed it from `tanis` to `tanis.md`. However, I suggest changing it to `README.md` because it will not be readable when people want to check the project.

Also, I have added my Farcaster account to the `builder_follow_builder.md` file.